### PR TITLE
Add manifest for servicemonitor

### DIFF
--- a/ingresses/traefik-service.yaml
+++ b/ingresses/traefik-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: traefik
+  labels:
+    app: traefik
 spec:
   type: NodePort
   ports:

--- a/ingresses/traefik-servicemonitor.yaml
+++ b/ingresses/traefik-servicemonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: traefik-metrics
+spec:
+  selector:
+    matchLabels:
+      app: traefik
+  endpoints:
+    - port: web
+      path: /metrics


### PR DESCRIPTION
- The Prometheus Operator does not support annotation-based discovery of services with Kube Prometheus Stack's Helm chart.
- It recommends PodMonitors/ServiceMonitors as they provide far more configuration options. [reference](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/#prometheusioscrape)